### PR TITLE
set az count on es cluster to set multiple subnets

### DIFF
--- a/elasticsearch.cfhighlander.rb
+++ b/elasticsearch.cfhighlander.rb
@@ -3,6 +3,7 @@ CfhighlanderTemplate do
   Parameters do
     ComponentParam 'EnvironmentName', 'dev', isGlobal: true
     ComponentParam 'EnvironmentType', 'development', allowedValues: ['development','production'], isGlobal: true
+    ComponentParam 'AvailabilityZones', 1, isGlobal: true, allowedValues: [1,2,3]
     
     ComponentParam 'VPCId', type: 'AWS::EC2::VPC::Id'
     ComponentParam 'Subnets'


### PR DESCRIPTION
@aaronwalker for some reason you have to set the `AvailabilityZoneCount` value in the cluster config to match the amount of subnets you give to the domain. The condition could be better but i can fix that up later if someone wants more than 3 azs.

The other thing to be aware of is you have to have a multiple azs for data nodes, as in if you have 2 azs you have to have either 2, 4, 6... data nodes