### PR TITLE
Add fnif for zone awareness config

### DIFF
--- a/elasticsearch.cfndsl.rb
+++ b/elasticsearch.cfndsl.rb
@@ -63,9 +63,12 @@ CloudFormation do
       InstanceCount: Ref('InstanceCount'),
       InstanceType: Ref('InstanceType'),
       ZoneAwarenessEnabled: FnIf('ZoneAwarenessEnabled', 'true','false'),
-      ZoneAwarenessConfig: {
-        AvailabilityZoneCount: Ref(:AvailabilityZones)
-      }
+      ZoneAwarenessConfig: FnIf('ZoneAwarenessEnabled', 
+        {
+          AvailabilityZoneCount: Ref(:AvailabilityZones)
+        },
+        Ref('AWS::NoValue')
+      )
     })
     ElasticsearchVersion Ref('ElasticsearchVersion')
     EncryptionAtRestOptions({


### PR DESCRIPTION
You can only set the ZoneAwarenessConfig property if ZoneAwarenessEnabled is true. If it is false cloudformation will still set the property which will fail the creation of the resource. Adding the condition with NoValue if ZoneAwarenessEnabled is false handles this correctly.